### PR TITLE
Added new parameter 'aci-external-l3-domain' to name a pre-existing

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -60,6 +60,10 @@ options:
     type: boolean
     default: False
     description: "Enable neutron sfc extensions"
+  aci-external-l3-domain:
+    type: string
+    default:
+    description: "Defaulf external routed domain to attach to l3out (SVI)"
   aci-mechanism-drivers:
     type: string
     default: apic_aim


### PR DESCRIPTION
l3-domain to automatcally attach to SVI/L3-Out created by neutron.