### PR TITLE
Added a parameter aci-aim-system-id to explicitly set id string for a…

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,13 @@ options:
     type: string
     default: 'openstack'
     description: "As id string for this openstack instance"
+  aci-aim-system-id:
+    type: string
+    default: ''
+    description: |
+        An id string for this aim instance, this should not be set unless specifically required for
+        upgrade from older versions. In all other cases this will be automatcally set to the
+        value of apic-system-id
   aci-apic-entity-profile:
     type: string
     default: 'openstack'

--- a/hooks/aim_context.py
+++ b/hooks/aim_context.py
@@ -13,6 +13,10 @@ class AciAimConfigContext(context.OSContextGenerator):
         ctxt['apic_hosts'] = config('aci-apic-hosts')
         ctxt['apic_username'] = config('aci-apic-username')
         ctxt['apic_password'] = config('aci-apic-password')
+        if config('aci-aim-system-id') == '':
+           ctxt['aci_aim_system_id'] = config('aci-apic-system-id')
+        else:
+           ctxt['aci_aim_system_id'] = config('aci-aim-system-id')
 
         return ctxt
 

--- a/templates/mitaka/aim.conf
+++ b/templates/mitaka/aim.conf
@@ -46,7 +46,7 @@ sql_connection = {{ database_type }}://{{ database_user }}:{{ database_password 
 # agent_down_time = 75
 agent_down_time = 75
 poll_config = False
-aim_system_id = openstack_aid
+aim_system_id = {{ aci_aim_system_id }}
 
 [apic]
 # Hostname:port list of APIC controllers


### PR DESCRIPTION
…im_system_id, this should

not be set unless specifically required for upgrade from older versions. In all other cases this
will be automatcally set to the value of apic-system-id. Upgrade to this version may change the
value of aim_system_id which maybe destructive.
TODO: detect that aim_system_id will change during an upgrade and produce warning to set this
value to openstack_aid (previously hardcoded value)