### PR TITLE
[Juju] Fix for upgrade where the aim_system_id would change

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,13 @@ options:
     type: string
     default: 'openstack'
     description: "As id string for this openstack instance"
+  aci-aim-system-id:
+    type: string
+    default: ''
+    description: |
+        An id string for this aim instance, an internal variable that should not be set unless
+        specifically required for upgrade from older versions. In all other cases this will be
+        automatcally set to the value of apic-system-id
   aci-apic-entity-profile:
     type: string
     default: 'openstack'

--- a/hooks/aci_hooks.py
+++ b/hooks/aci_hooks.py
@@ -145,6 +145,22 @@ def shared_db_changed():
 
 @hooks.hook('upgrade-charm')    
 def upgrade_charm():
+    if config('aci-aim-system-id') == '':
+       new_aim_system_id = config('aci-apic-system-id')
+    else:
+       new_aim_system_id = config('aci-aim-system-id')
+    
+    my_aim_system_id = ""
+    stream = os.popen('/usr/bin/aimctl -f json manager configuration-get aim_system_id "" aim')
+    myoutput = json.load(stream)
+    for item in myoutput:
+        if item["Property"] == "value":
+            my_aim_system_id = item["Value"]
+            break
+    log('my-aim-system-id: {} new-aim-sys-id: {}'.format(my_aim_system_id, new_aim_system_id))
+    if new_aim_system_id != my_aim_system_id:
+        log("Wont Upgrade aim-system-id will change, manual uograde required. Please set \"aci-aim-system-id: openstack_aid\"")
+        exit(5)
     aci_install()
     config_changed()
 

--- a/hooks/aim_context.py
+++ b/hooks/aim_context.py
@@ -13,6 +13,10 @@ class AciAimConfigContext(context.OSContextGenerator):
         ctxt['apic_hosts'] = config('aci-apic-hosts')
         ctxt['apic_username'] = config('aci-apic-username')
         ctxt['apic_password'] = config('aci-apic-password')
+        if config('aci-aim-system-id') == '':
+           ctxt['aci_aim_system_id'] = config('aci-apic-system-id')
+        else:
+           ctxt['aci_aim_system_id'] = config('aci-aim-system-id')
 
         return ctxt
 

--- a/templates/mitaka/aim.conf
+++ b/templates/mitaka/aim.conf
@@ -46,7 +46,7 @@ sql_connection = {{ database_type }}://{{ database_user }}:{{ database_password 
 # agent_down_time = 75
 agent_down_time = 75
 poll_config = False
-aim_system_id = openstack_aid
+aim_system_id = {{ aci_aim_system_id }}
 
 [apic]
 # Hostname:port list of APIC controllers
@@ -63,3 +63,4 @@ apic_username = {{ apic_username }}
 apic_password = {{ apic_password }}
 apic_use_ssl = True
 verify_ssl_certificate=False
+


### PR DESCRIPTION
Older versions have hardcoded value openstack_oid for the variable
aim_system_id. This fix will require manually adding string
aci-aim-system-id: openstack_aid to charm config during upgrade if
the value will change as a result of upgrade, otherwise upgrade
will fail and will produce log message asking to manually set the value.