### PR TITLE
Disabled services not needed by neutron-api

### DIFF
--- a/hooks/aci_hooks.py
+++ b/hooks/aci_hooks.py
@@ -70,6 +70,19 @@ def aci_install(relation_id=None):
 
     fetch.apt_install(ACI_PACKAGES, options=opt, fatal=True)
 
+    cmd = ['/bin/systemctl', 'stop', 'neutron-opflex-agent']
+    subprocess.check_call(cmd)
+
+    cmd = ['/bin/systemctl', 'disable', 'neutron-opflex-agent']
+    subprocess.check_call(cmd)
+
+    cmd = ['/bin/systemctl', 'stop', 'neutron-cisco-apic-host-agent']
+    subprocess.check_call(cmd)
+
+    cmd = ['/bin/systemctl', 'disable', 'neutron-cisco-apic-host-agent']
+    subprocess.check_call(cmd)
+
+
 @hooks.hook('update-status')
 def update_status():
     log("Updating status")

--- a/hooks/aci_utils.py
+++ b/hooks/aci_utils.py
@@ -60,7 +60,7 @@ else:
 
 AIM_CONFIG = '/etc/aim/aim.conf'
 AIM_CTL_CONFIG = '/etc/aim/aimctl.conf'
-AIM_SERVICES = ['aim-aid','aim-event-service-rpc', 'aim-event-service-polling', 'neutron-cisco-apic-host-agent']
+AIM_SERVICES = ['aim-aid','aim-event-service-rpc', 'aim-event-service-polling']
 NEUTRON_CONF_DIR = "/etc/neutron"
 NEUTRON_CONF = '%s/neutron.conf' % NEUTRON_CONF_DIR
 TEMPLATES = 'templates/'


### PR DESCRIPTION
Disables neutron-cisco-apic-host-agent and neutron-cisco-apic-host-agent.